### PR TITLE
Add food scraps entry

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.yaml": "home-assistant"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ A Home Assistant custom component grep the rubbish and recycle (food scraps soon
 
 ## Version
 
-| Version | Notes                 |
-| ------- | --------------------- |
-| 0.1.0   | First publish release |
+| Version | Notes                                                                  |
+| ------- | ---------------------------------------------------------------------- |
+| 0.1.0   | First publish release                                                  |
+| 0.2.0   | Update with Auckland Council website to include food scraps collection |
 
 ## Installation
 
@@ -45,6 +46,7 @@ The table below shows the attributes of the sensor.
 | date | Date string retrieve from the Auckland Council webpage. |
 | rubbish | `true` or `false` - Rubbish bin will be collected or not. |
 | recycle | `true` or `false` - Recycle bin will be collected or not. |
+| food scraps | `true` or `false` - Food scraps bin will be collected or not. |
 | query_url | The URL where the information retrieved from. |
 | friendly_name | Sensor's friendly name. |
 
@@ -53,9 +55,9 @@ The table below shows the attributes of the sensor.
 You can add a Markdown Card on your Home Assistant Dashboard with the following content:
 
 ```
-Upcoming: **{{ state_attr('sensor.auckland_bin_collection_upcoming', 'date') }}**{% if state_attr('sensor.auckland_bin_collection_upcoming', 'rubbish') == 'true' %} <ha-icon icon="mdi:trash-can-outline"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_upcoming', 'recycle') == 'true' %} <ha-icon icon="mdi:recycle"></ha-icon>{% endif %}
+Upcoming: **{{ state_attr('sensor.auckland_bin_collection_upcoming', 'date') }}**{% if state_attr('sensor.auckland_bin_collection_upcoming', 'rubbish') == 'true' %} <ha-icon icon="mdi:trash-can-outline"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_upcoming', 'recycle') == 'true' %} <ha-icon icon="mdi:recycle"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_upcoming', 'food scraps') == 'true' %} <ha-icon icon="mdi:compost"></ha-icon>{% endif %}
 
-Next:  **{{ state_attr('sensor.auckland_bin_collection_next', 'date') }}**{% if state_attr('sensor.auckland_bin_collection_next', 'rubbish') == 'true' %} <ha-icon icon="mdi:trash-can-outline"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_next', 'recycle') == 'true' %}<ha-icon icon="mdi:recycle"></ha-icon>{% endif %}
+Next:  **{{ state_attr('sensor.auckland_bin_collection_next', 'date') }}**{% if state_attr('sensor.auckland_bin_collection_next', 'rubbish') == 'true' %} <ha-icon icon="mdi:trash-can-outline"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_next', 'recycle') == 'true' %}<ha-icon icon="mdi:recycle"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_next', 'food scraps') == 'true' %} <ha-icon icon="mdi:compost"></ha-icon>{% endif %}
 ```
 
 Result will look like this.

--- a/custom_components/auckland_bin_collection/manifest.json
+++ b/custom_components/auckland_bin_collection/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/fishy242/home-assistant-core",
   "iot_class": "cloud_polling",
   "requirements": ["beautifulsoup4==4.12.0"],
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/custom_components/auckland_bin_collection/sensor.py
+++ b/custom_components/auckland_bin_collection/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 import pytz
 import requests
 
-from .const import CONF_LOCATION_ID, DOMAIN
+#from .const import CONF_LOCATION_ID, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,27 +49,32 @@ async def async_get_bin_dates(hass: HomeAssistant, location_id: str):
     url = f"{URL_REQUEST}{location_id}"
     response = await hass.async_add_executor_job(requests.get, url)
 
+#def sensor_test():
+#    location_id = "12342731560"
+    url = f"{URL_REQUEST}{location_id}"
+    response = requests.get(url)
     soup = BeautifulSoup(response.text, "html.parser")
-    household = soup.find_all("div", {"id": lambda x: x and "HouseholdBlock" in x})
+    household = soup.find_all("div", {"id": lambda x: x and "HouseholdBlock2" in x})
 
     if not household:
         raise ValueError("Data with location ID not found")
 
     result = []
     # We can assume only one Household Block
-    for collect_date in household[0].find_all("span", {"class": "m-r-1"}):
-        collect_types = []
-        for sibling in collect_date.find_next_siblings():
-            collect_type = sibling.find("span", {"class": "sr-only"})
-            if collect_type:
-                collect_types.append(collect_type.text)
-        result.append({KEY_DATE: collect_date.text, KEY_TYPE: collect_types})
+    for date_block in household[0].find_all("h5", {"class": "collectionDayDate"}):
+        collect_type = date_block.find("span", {"class": "sr-only"})
+        collect_date = date_block.find("strong")
+        if collect_date and collect_type:
+            result.append({KEY_DATE: collect_date.text, KEY_TYPE: collect_type.text})
 
     if not result:
         raise ValueError("Cannot retrieve bin dates")
 
+    print(f"return: {result}")
     return result
 
+#if __name__ == "__main__":
+ #   sensor_test()
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback

--- a/custom_components/auckland_bin_collection/sensor.py
+++ b/custom_components/auckland_bin_collection/sensor.py
@@ -132,7 +132,7 @@ class AucklandBinCollection(SensorEntity):
         try:
             data = self.coordinator.data[self._date_index]
         except IndexError:
-            _LOGGER.warn(
+            _LOGGER.warning(
                 "coordinator.data with _date_index: %d not ready yet", self._date_index
             )
             return None
@@ -148,7 +148,7 @@ class AucklandBinCollection(SensorEntity):
         try:
             data = self.coordinator.data[self._date_index]
         except IndexError:
-            _LOGGER.warn(
+            _LOGGER.warning(
                 "coordinator.data with _date_index: %d not ready yet", self._date_index
             )
             return None

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,3 +1,6 @@
 beautifulsoup4==4.12.0
 freezegun==1.2.2
-pytest-homeassistant-custom-component
+pytest==7.2.1
+pytest-cov==3.0.0
+pytest-asyncio==0.20.2
+pytest-homeassistant-custom-component==0.12.55

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 """pytest fixtures."""
-import pytest_asyncio
+import pytest
 
 
-@pytest_asyncio.fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable custom integrations defined in the test dir."""
-    yield
+    yield enable_custom_integrations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,6 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def auto_enable_custom_integrations(enable_custom_integrations):
+async def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable custom integrations defined in the test dir."""
-    yield enable_custom_integrations
+    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,6 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-async def auto_enable_custom_integrations(enable_custom_integrations):
+def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable custom integrations defined in the test dir."""
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 """pytest fixtures."""
-import pytest
+import pytest_asyncio
 
 
-@pytest.fixture(autouse=True)
+@pytest_asyncio.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable custom integrations defined in the test dir."""
     yield

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -13,9 +13,7 @@ from custom_components.auckland_bin_collection.const import CONF_LOCATION_ID
 async def test_validate_location_id(mock_async_get_bin_dates, hass):
     """Test valid location id."""
 
-    mock_async_get_bin_dates.return_value = [
-        {"date": "Monday January 1", "type": "rubbish"}
-    ]
+    mock_async_get_bin_dates.return_value = [{"Monday January 1": ["Rubbish"]}]
     await config_flow.validate_location_id(hass, "12345678901")
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,9 +1,11 @@
 """Test component setup."""
 from homeassistant.setup import async_setup_component
+import pytest
 
 from custom_components.auckland_bin_collection.const import DOMAIN
 
 
+@pytest.mark.asyncio
 async def test_async_setup(hass):
     """Test the component gets setup."""
     assert await async_setup_component(hass, DOMAIN, {}) is True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -13,15 +13,17 @@ from custom_components.auckland_bin_collection.sensor import (
 
 TEST_LOC = "12345678901"
 TEST_UPCOMING_DATE_STR = "Tuesday 12 January"
-TEST_UPCOMING_TYPE_STR = ["Rubbish"]
+TEST_UPCOMING_TYPE_STR = ["Rubbish", "Food scraps"]
 TEST_UPCOMING_DATE = date(2023, 1, 12)
 TEST_UPCOMING_RUBBISH = "true"
 TEST_UPCOMING_RECYCLE = "false"
+TEST_UPCOMING_FOODSCRAPS = "true"
 TEST_UPCOMING_ATTRS = {
     "location_id": TEST_LOC,
     "date": TEST_UPCOMING_DATE_STR,
     "rubbish": TEST_UPCOMING_RUBBISH,
     "recycle": TEST_UPCOMING_RECYCLE,
+    "food scraps": TEST_UPCOMING_FOODSCRAPS,
     "query_url": f"{URL_REQUEST}{TEST_LOC}",
 }
 
@@ -30,17 +32,19 @@ TEST_NEXT_TYPE_STR = ["Rubbish", "Recycle"]
 TEST_NEXT_DATE = date(2023, 3, 25)
 TEST_NEXT_RUBBISH = "true"
 TEST_NEXT_RECYCLE = "true"
+TEST_NEXT_FOODSCRAPS = "false"
 TEST_NEXT_ATTRS = {
     "location_id": TEST_LOC,
     "date": TEST_NEXT_DATE_STR,
     "rubbish": TEST_NEXT_RUBBISH,
     "recycle": TEST_NEXT_RECYCLE,
+    "food scraps": TEST_NEXT_FOODSCRAPS,
     "query_url": f"{URL_REQUEST}{TEST_LOC}",
 }
 
 TEST_COORDINATOR_DATA = [
-    {"date": TEST_UPCOMING_DATE_STR, "type": TEST_UPCOMING_TYPE_STR},
-    {"date": TEST_NEXT_DATE_STR, "type": TEST_NEXT_TYPE_STR},
+    {TEST_UPCOMING_DATE_STR: TEST_UPCOMING_TYPE_STR},
+    {TEST_NEXT_DATE_STR: TEST_NEXT_TYPE_STR},
 ]
 
 


### PR DESCRIPTION
Change according to the Auckland Council website update to include Food Scraps collection.

**changes**
- update web parser to include food scraps collection
- add food scraps in sensor attribute
- update unit test accordingly
- update version to 0.2.0
- fix pytest-* components version in requirements.test.txt