### PR TITLE
Add user-agent header to HTTP request for bin dates

### DIFF
--- a/custom_components/auckland_bin_collection/sensor.py
+++ b/custom_components/auckland_bin_collection/sensor.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta
 import logging
 from typing import Any
+from functools import partial
 
 from bs4 import BeautifulSoup
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
@@ -21,7 +22,8 @@ _LOGGER = logging.getLogger(__name__)
 KEY_DATE = "date"
 KEY_TYPE = "type"
 URL_REQUEST = "https://www.aucklandcouncil.govt.nz/en/rubbish-recycling/rubbish-recycling-collections/rubbish-recycling-collection-days/"
-
+# Currently will work with any user-agent string
+UA_HEADER = "HA-Getter"
 
 def get_date_from_str(date_str: str) -> datetime.date:
     """Convert a date string to date object"""
@@ -47,7 +49,9 @@ async def async_get_bin_dates(hass: HomeAssistant, location_id: str):
     """Async method to get data from Auckland Council webpage."""
 
     url = f"{URL_REQUEST}{location_id}.html"
-    response = await hass.async_add_executor_job(requests.get, url)
+    agent_header = {"User-Agent": UA_HEADER}
+    req_func = partial(requests.get, url, headers=agent_header)
+    response = await hass.async_add_executor_job(req_func)
 
     if response.status_code != 200:
         raise Exception(f"Failed to fetch page: {response.status_code}")


### PR DESCRIPTION
Add UA header to circumvent council page HTTP-406 error. Feel free to change UA string to anything you see fit.