### PR TITLE
Less frequent polling

### DIFF
--- a/custom_components/auckland_bin_collection/sensor.py
+++ b/custom_components/auckland_bin_collection/sensor.py
@@ -2,16 +2,18 @@
 
 from datetime import datetime, timedelta
 import logging
+import random
 from typing import Any
 from functools import partial
 
 from bs4 import BeautifulSoup
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later, async_track_point_in_time
 from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 import pytz
 import requests
 
@@ -23,6 +25,14 @@ KEY_DATE = "date"
 KEY_TYPE = "type"
 URL_REQUEST = "https://www.aucklandcouncil.govt.nz/en/rubbish-recycling/rubbish-recycling-collections/rubbish-recycling-collection-days/"
 UA_HEADER = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36 Edg/144.0.0.0"
+
+# Scheduling configuration
+POLL_TIMEZONE = pytz.timezone("Pacific/Auckland")
+POLL_HOUR = 6          # Daily poll target: 6:00 AM NZ time
+POLL_JITTER_MINUTES = 30   # ± random variation around the target time (minutes)
+RETRY_MIN_MINUTES = 30     # Minimum retry delay after a failed poll (minutes)
+RETRY_MAX_MINUTES = 90     # Maximum retry delay after a failed poll (minutes)
+
 
 def get_date_from_str(date_str: str) -> datetime.date:
     """Convert a date string to date object"""
@@ -48,18 +58,18 @@ async def async_get_bin_dates(hass: HomeAssistant, location_id: str):
     """Async method to get data from Auckland Council webpage."""
 
     url = f"{URL_REQUEST}{location_id}.html"
-    agent_header = {"User-Agent": UA_HEADER, "Accept-Encoding":"gzip, deflate, br, zstd", "Accept-Language": "en-NZ,en;q=0.9"}
+    agent_header = {"User-Agent": UA_HEADER, "Accept-Encoding": "gzip, deflate, br, zstd", "Accept-Language": "en-NZ,en;q=0.9"}
     req_func = partial(requests.get, url, headers=agent_header)
     response = await hass.async_add_executor_job(req_func)
 
     if response.status_code != 200:
-        raise Exception(f"Failed to fetch page: {response.status_code}")
+        raise UpdateFailed(f"Failed to fetch page: {response.status_code}")
 
     soup = BeautifulSoup(response.text, "html.parser")
     schedules = soup.find_all("div", {"class": "acpl-schedule-card"})
 
     if not schedules:
-        raise ValueError("Data with location ID not found")
+        raise UpdateFailed("Data with location ID not found")
 
     extracted_data = []
     # We can assume first block is the household schedule
@@ -72,7 +82,7 @@ async def async_get_bin_dates(hass: HomeAssistant, location_id: str):
                 extracted_data.append((collect_date.text, collect_type))
 
     if not extracted_data:
-        raise ValueError("Cannot retrieve bin dates")
+        raise UpdateFailed("Cannot retrieve bin dates")
 
     data_dict = {}
     for collect_date, collect_type in extracted_data:
@@ -86,6 +96,107 @@ async def async_get_bin_dates(hass: HomeAssistant, location_id: str):
     return sorted_data
 
 
+def _next_poll_time() -> datetime:
+    """Calculate the next daily poll time: POLL_HOUR NZ time ± POLL_JITTER_MINUTES."""
+    now = datetime.now(POLL_TIMEZONE)
+    jitter = random.randint(-POLL_JITTER_MINUTES, POLL_JITTER_MINUTES)
+    target = now.replace(hour=POLL_HOUR, minute=0, second=0, microsecond=0) + timedelta(minutes=jitter)
+
+    # If the target time today has already passed, schedule for tomorrow
+    if target <= now:
+        target += timedelta(days=1)
+
+    _LOGGER.debug(
+        "Next scheduled poll at %s (jitter: %+d min)",
+        target.strftime("%Y-%m-%d %H:%M:%S %Z"),
+        jitter,
+    )
+    return target
+
+
+class BinCollectionCoordinator(DataUpdateCoordinator):
+    """Custom coordinator that polls once daily at a fixed NZ time with random jitter.
+
+    On failure, it schedules a retry after a random delay instead of waiting
+    until the next daily window, to recover data without hammering the server.
+    """
+
+    def __init__(self, hass: HomeAssistant, location_id: str) -> None:
+        super().__init__(
+            hass=hass,
+            logger=_LOGGER,
+            name=DOMAIN,
+            # No fixed update_interval — we manage scheduling ourselves
+            update_interval=None,
+        )
+        self._location_id = location_id
+        self._unsub_scheduled: callback | None = None
+
+    async def async_start(self) -> None:
+        """Start the coordinator: fetch immediately if no data, then schedule daily polls."""
+        _LOGGER.debug("BinCollectionCoordinator starting")
+        await self.async_refresh()  # Initial fetch on startup
+        self._schedule_next_poll()
+
+    def _schedule_next_poll(self) -> None:
+        """Schedule the next daily poll at the target time with jitter."""
+        self._cancel_scheduled()
+        next_time = _next_poll_time()
+
+        @callback
+        def _scheduled_refresh(_now: datetime) -> None:
+            self.hass.async_create_task(self._do_scheduled_refresh())
+
+        self._unsub_scheduled = async_track_point_in_time(
+            self.hass, _scheduled_refresh, next_time
+        )
+
+    def _schedule_retry(self) -> None:
+        """Schedule a retry after a random delay following a failed poll."""
+        self._cancel_scheduled()
+        delay_minutes = random.randint(RETRY_MIN_MINUTES, RETRY_MAX_MINUTES)
+        delay_seconds = delay_minutes * 60
+
+        _LOGGER.warning(
+            "Last poll failed — retrying in %d minutes", delay_minutes
+        )
+
+        @callback
+        def _retry_refresh(_now: datetime) -> None:
+            self.hass.async_create_task(self._do_scheduled_refresh())
+
+        self._unsub_scheduled = async_call_later(
+            self.hass, delay_seconds, _retry_refresh
+        )
+
+    async def _do_scheduled_refresh(self) -> None:
+        """Perform a scheduled refresh, then schedule the next poll or a retry."""
+        try:
+            await self.async_refresh()
+            if self.last_update_success:
+                _LOGGER.debug("Scheduled poll succeeded — scheduling next daily poll")
+                self._schedule_next_poll()
+            else:
+                self._schedule_retry()
+        except Exception:  # noqa: BLE001
+            self._schedule_retry()
+
+    def _cancel_scheduled(self) -> None:
+        """Cancel any pending scheduled callback."""
+        if self._unsub_scheduled is not None:
+            self._unsub_scheduled()
+            self._unsub_scheduled = None
+
+    async def _async_update_data(self):
+        """Fetch data from the Auckland Council website."""
+        return await async_get_bin_dates(self.hass, self._location_id)
+
+    async def async_shutdown(self) -> None:
+        """Cancel scheduled polls on shutdown."""
+        self._cancel_scheduled()
+        await super().async_shutdown()
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -93,13 +204,8 @@ async def async_setup_entry(
 
     location_id = entry.data[CONF_LOCATION_ID]
 
-    coordinator = DataUpdateCoordinator(
-        hass=hass,
-        logger=_LOGGER,
-        update_method=lambda: async_get_bin_dates(hass, location_id),
-        name=DOMAIN,
-        update_interval=timedelta(hours=1),
-    )
+    coordinator = BinCollectionCoordinator(hass, location_id)
+    await coordinator.async_start()
 
     async_add_entities(
         [

--- a/custom_components/auckland_bin_collection/sensor.py
+++ b/custom_components/auckland_bin_collection/sensor.py
@@ -131,6 +131,7 @@ class BinCollectionCoordinator(DataUpdateCoordinator):
         )
         self._location_id = location_id
         self._unsub_scheduled: callback | None = None
+        self._last_updated: datetime | None = None
 
     async def async_start(self) -> None:
         """Start the coordinator: fetch immediately if no data, then schedule daily polls."""
@@ -189,7 +190,9 @@ class BinCollectionCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         """Fetch data from the Auckland Council website."""
-        return await async_get_bin_dates(self.hass, self._location_id)
+        result = await async_get_bin_dates(self.hass, self._location_id)
+        self._last_updated = datetime.now(POLL_TIMEZONE)
+        return result
 
     async def async_shutdown(self) -> None:
         """Cancel scheduled polls on shutdown."""
@@ -263,6 +266,7 @@ class AucklandBinCollection(SensorEntity):
             return None
 
         date = list(data.keys())[0]
+        last_updated = self.coordinator._last_updated
         return {
             "location_id": self._location_id,
             "date": date,
@@ -270,6 +274,7 @@ class AucklandBinCollection(SensorEntity):
             "recycle": "true" if "Recycling" in data[date] else "false",
             "food scraps": "true" if "Food scraps" in data[date] else "false",
             "query_url": f"{URL_REQUEST}{self._location_id}",
+            "last_updated": last_updated.isoformat() if last_updated else None,
         }
 
     @property

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -35,6 +35,7 @@ TEST_UPCOMING_ATTRS = {
     "recycle": TEST_UPCOMING_RECYCLE,
     "food scraps": TEST_UPCOMING_FOODSCRAPS,
     "query_url": f"{URL_REQUEST}{TEST_LOC}",
+    "last_updated": None,
 }
 
 TEST_NEXT_DATE_STR = "Friday, 25 March"
@@ -50,6 +51,7 @@ TEST_NEXT_ATTRS = {
     "recycle": TEST_NEXT_RECYCLE,
     "food scraps": TEST_NEXT_FOODSCRAPS,
     "query_url": f"{URL_REQUEST}{TEST_LOC}",
+    "last_updated": None,
 }
 
 TEST_COORDINATOR_DATA = [
@@ -89,6 +91,7 @@ async def test_update_upcoming_success():
     """Test upcoming collection successful update."""
     _coordinator = AsyncMock()
     _coordinator.data = TEST_COORDINATOR_DATA
+    _coordinator._last_updated = None
     upcoming = AucklandBinCollection(_coordinator, TEST_LOC, "upcoming", 0)
     await upcoming.async_update()
     assert upcoming.state == TEST_UPCOMING_STATE
@@ -101,6 +104,7 @@ async def test_update_next_success():
     """Test next collection successful update."""
     m_coordinator = AsyncMock()
     m_coordinator.data = TEST_COORDINATOR_DATA
+    m_coordinator._last_updated = None
     next = AucklandBinCollection(m_coordinator, TEST_LOC, "next", 1)
     await next.async_update()
     assert next.state == TEST_NEXT_STATE
@@ -324,6 +328,27 @@ SAMPLE_HTML = """
 </div>
 </body></html>
 """
+
+
+@pytest.mark.asyncio
+@freeze_time("2024-06-01 03:00:00")
+async def test_async_update_data_sets_last_updated(hass):
+    """_async_update_data should stamp _last_updated with the current NZ time."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = SAMPLE_HTML
+    hass.async_add_executor_job = AsyncMock(return_value=mock_response)
+
+    coordinator = BinCollectionCoordinator(hass, TEST_LOC)
+    assert coordinator._last_updated is None
+
+    await coordinator._async_update_data()
+
+    assert coordinator._last_updated is not None
+    # Should be timezone-aware (NZ tz)
+    assert coordinator._last_updated.tzinfo is not None
+    # Frozen at 2024-06-01 03:00 UTC → 15:00 NZ
+    assert coordinator._last_updated.strftime("%H:%M") == "15:00"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,13 +1,23 @@
 """Test for Auckland Bin Collection sensor."""
-from datetime import date
-from unittest.mock import AsyncMock, MagicMock
+from datetime import date, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch, call
 
 from freezegun import freeze_time
 import pytest
+import pytz
 
 from custom_components.auckland_bin_collection.sensor import (
     URL_REQUEST,
     AucklandBinCollection,
+    BinCollectionCoordinator,
+    POLL_HOUR,
+    POLL_JITTER_MINUTES,
+    RETRY_MIN_MINUTES,
+    RETRY_MAX_MINUTES,
+    POLL_TIMEZONE,
+    _next_poll_time,
+    async_get_bin_dates,
+    async_setup_entry,
     get_date_from_str,
 )
 
@@ -137,3 +147,381 @@ def test_name():
     m_coordinator = MagicMock()
     sensor = AucklandBinCollection(m_coordinator, TEST_LOC, "test_sensor", 0)
     assert sensor.name == "test_sensor"
+
+
+# ---------------------------------------------------------------------------
+# BinCollectionCoordinator tests
+# ---------------------------------------------------------------------------
+
+TZ_NZ = pytz.timezone("Pacific/Auckland")
+
+
+# --- _next_poll_time --------------------------------------------------------
+
+@freeze_time("2024-06-01 03:00:00")  # 3 AM UTC → 15:00 NZ (before 6 AM next day)
+def test_next_poll_time_is_in_future():
+    """_next_poll_time should always return a time in the future."""
+    next_time = _next_poll_time()
+    now = datetime.now(TZ_NZ)
+    assert next_time > now
+
+
+@freeze_time("2024-06-01 03:00:00")  # 15:00 NZ — daily target (6 AM) already past
+def test_next_poll_time_schedules_tomorrow_when_past():
+    """When 6 AM today has already passed, schedule for tomorrow."""
+    next_time = _next_poll_time()
+    now = datetime.now(TZ_NZ)
+    assert next_time.date() == (now + timedelta(days=1)).date()
+
+
+@freeze_time("2024-06-01 17:00:00")  # 05:00 NZ — just before 6 AM
+def test_next_poll_time_schedules_today_when_not_yet_reached():
+    """When 6 AM today has not yet occurred, schedule for today."""
+    next_time = _next_poll_time()
+    now = datetime.now(TZ_NZ)
+    assert next_time.date() == now.date()
+
+
+@freeze_time("2024-06-01 03:00:00")
+def test_next_poll_time_within_jitter_bounds():
+    """The scheduled time must be within POLL_HOUR ± POLL_JITTER_MINUTES."""
+    # Run many times to exercise the random jitter
+    for _ in range(50):
+        next_time = _next_poll_time()
+        # Convert to NZ local time for comparison
+        local = next_time.astimezone(TZ_NZ)
+        base = local.replace(hour=POLL_HOUR, minute=0, second=0, microsecond=0)
+        diff_minutes = abs((local - base).total_seconds()) / 60
+        assert diff_minutes <= POLL_JITTER_MINUTES + 1  # +1 for float rounding
+
+
+# --- async_start ------------------------------------------------------------
+
+async def test_coordinator_async_start_refreshes_and_schedules(hass):
+    """async_start should perform an initial refresh and schedule the next poll."""
+    with (
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_get_bin_dates",
+            new_callable=AsyncMock,
+            return_value=[["dummy"]],
+        ),
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_track_point_in_time",
+            return_value=MagicMock(),
+        ) as mock_track,
+    ):
+        coordinator = BinCollectionCoordinator(hass, TEST_LOC)
+        await coordinator.async_start()
+
+        # A daily poll must have been scheduled
+        assert mock_track.called
+
+
+# --- retry on failure -------------------------------------------------------
+
+async def test_coordinator_schedules_retry_on_fetch_failure(hass):
+    """A failed initial fetch should schedule a retry via async_call_later."""
+    with (
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_get_bin_dates",
+            new_callable=AsyncMock,
+            side_effect=Exception("network error"),
+        ),
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_call_later",
+            return_value=MagicMock(),
+        ) as mock_later,
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_track_point_in_time",
+            return_value=MagicMock(),
+        ),
+    ):
+        coordinator = BinCollectionCoordinator(hass, TEST_LOC)
+        # Simulate a failed scheduled refresh (not async_start, to skip init fetch)
+        coordinator._unsub_scheduled = None
+        await coordinator._do_scheduled_refresh()
+
+        assert mock_later.called
+        delay_seconds = mock_later.call_args[0][1]
+        assert RETRY_MIN_MINUTES * 60 <= delay_seconds <= RETRY_MAX_MINUTES * 60
+
+
+# --- success re-schedules daily poll ----------------------------------------
+
+async def test_coordinator_reschedules_daily_poll_after_success(hass):
+    """After a successful scheduled refresh, the next daily poll should be queued."""
+    with (
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_get_bin_dates",
+            new_callable=AsyncMock,
+            return_value=[["dummy"]],
+        ),
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_track_point_in_time",
+            return_value=MagicMock(),
+        ) as mock_track,
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_call_later",
+            return_value=MagicMock(),
+        ) as mock_later,
+    ):
+        coordinator = BinCollectionCoordinator(hass, TEST_LOC)
+        await coordinator._do_scheduled_refresh()
+
+        # Daily poll scheduled; retry must NOT have been called
+        assert mock_track.called
+        assert not mock_later.called
+
+
+# --- shutdown ---------------------------------------------------------------
+
+async def test_coordinator_shutdown_cancels_scheduled(hass):
+    """async_shutdown should cancel any pending scheduled callback."""
+    mock_unsub = MagicMock()
+    with (
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_get_bin_dates",
+            new_callable=AsyncMock,
+            return_value=[["dummy"]],
+        ),
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_track_point_in_time",
+            return_value=mock_unsub,
+        ),
+    ):
+        coordinator = BinCollectionCoordinator(hass, TEST_LOC)
+        await coordinator.async_start()
+
+        assert coordinator._unsub_scheduled is mock_unsub
+        await coordinator.async_shutdown()
+
+        mock_unsub.assert_called_once()  # The cancel callable was invoked
+        assert coordinator._unsub_scheduled is None
+
+
+# ---------------------------------------------------------------------------
+# async_get_bin_dates tests
+# ---------------------------------------------------------------------------
+
+SAMPLE_HTML = """
+<html><body>
+<div class="acpl-schedule-card">
+  <span class="acpl-icon-with-attribute left">
+    <span class="">
+      Rubbish:<b>Tuesday, 12 January</b>
+    </span>
+  </span>
+  <span class="acpl-icon-with-attribute left">
+    <span class="">
+      Food scraps:<b>Tuesday, 12 January</b>
+    </span>
+  </span>
+  <span class="acpl-icon-with-attribute left">
+    <span class="">
+      Recycling:<b>Friday, 25 March</b>
+    </span>
+  </span>
+</div>
+</body></html>
+"""
+
+
+@pytest.mark.asyncio
+async def test_async_get_bin_dates_success():
+    """async_get_bin_dates parses a well-formed page and returns sorted data."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = SAMPLE_HTML
+
+    mock_hass = MagicMock()
+    mock_hass.async_add_executor_job = AsyncMock(return_value=mock_response)
+
+    result = await async_get_bin_dates(mock_hass, TEST_LOC)
+
+    # Should return a list of dicts sorted by date
+    assert isinstance(result, list)
+    assert len(result) >= 1
+
+
+@pytest.mark.asyncio
+async def test_async_get_bin_dates_non_200_raises():
+    """async_get_bin_dates raises UpdateFailed on a non-200 HTTP response."""
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+
+    mock_hass = MagicMock()
+    mock_hass.async_add_executor_job = AsyncMock(return_value=mock_response)
+
+    with pytest.raises(UpdateFailed, match="404"):
+        await async_get_bin_dates(mock_hass, TEST_LOC)
+
+
+@pytest.mark.asyncio
+async def test_async_get_bin_dates_no_schedules_raises():
+    """async_get_bin_dates raises UpdateFailed when no schedule cards are found."""
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "<html><body><p>No data here</p></body></html>"
+
+    mock_hass = MagicMock()
+    mock_hass.async_add_executor_job = AsyncMock(return_value=mock_response)
+
+    with pytest.raises(UpdateFailed, match="not found"):
+        await async_get_bin_dates(mock_hass, TEST_LOC)
+
+
+@pytest.mark.asyncio
+async def test_async_get_bin_dates_empty_dates_raises():
+    """async_get_bin_dates raises UpdateFailed when schedule cards have no date entries."""
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    empty_html = """
+    <html><body>
+    <div class="acpl-schedule-card">
+      <span class="acpl-icon-with-attribute left">
+        <!-- no inner span with class="" -->
+      </span>
+    </div>
+    </body></html>
+    """
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = empty_html
+
+    mock_hass = MagicMock()
+    mock_hass.async_add_executor_job = AsyncMock(return_value=mock_response)
+
+    with pytest.raises(UpdateFailed, match="Cannot retrieve"):
+        await async_get_bin_dates(mock_hass, TEST_LOC)
+
+
+# ---------------------------------------------------------------------------
+# Inner callback coverage
+# ---------------------------------------------------------------------------
+
+async def test_scheduled_refresh_callback_fires(hass):
+    """The _scheduled_refresh inner callback passed to async_track_point_in_time
+    should create a task that runs _do_scheduled_refresh."""
+    captured_callback = None
+
+    def capture_track(h, cb, when):
+        nonlocal captured_callback
+        captured_callback = cb
+        return MagicMock()
+
+    with (
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_get_bin_dates",
+            new_callable=AsyncMock,
+            return_value=[["dummy"]],
+        ),
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_track_point_in_time",
+            side_effect=capture_track,
+        ),
+    ):
+        coordinator = BinCollectionCoordinator(hass, TEST_LOC)
+        await coordinator.async_start()
+
+    assert captured_callback is not None
+    # Invoking the callback should schedule a task — just verify it doesn't raise
+    captured_callback(datetime.now())
+
+
+async def test_retry_refresh_callback_fires(hass):
+    """The _retry_refresh inner callback passed to async_call_later
+    should create a task that runs _do_scheduled_refresh."""
+    captured_callback = None
+
+    def capture_later(h, delay, cb):
+        nonlocal captured_callback
+        captured_callback = cb
+        return MagicMock()
+
+    with (
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_get_bin_dates",
+            new_callable=AsyncMock,
+            side_effect=Exception("fail"),
+        ),
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_call_later",
+            side_effect=capture_later,
+        ),
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_track_point_in_time",
+            return_value=MagicMock(),
+        ),
+    ):
+        coordinator = BinCollectionCoordinator(hass, TEST_LOC)
+        coordinator._unsub_scheduled = None
+        await coordinator._do_scheduled_refresh()
+
+    assert captured_callback is not None
+    captured_callback(datetime.now())
+
+
+# ---------------------------------------------------------------------------
+# _do_scheduled_refresh bare-except branch (line 182)
+# ---------------------------------------------------------------------------
+
+async def test_do_scheduled_refresh_exception_schedules_retry(hass):
+    """An unexpected exception in async_refresh triggers _schedule_retry.
+
+    DataUpdateCoordinator.async_refresh() catches exceptions from
+    _async_update_data internally and never re-raises them, so patching
+    async_get_bin_dates is NOT enough to hit the bare `except` on line 182.
+    We must patch async_refresh itself to raise.
+    """
+    with (
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_call_later",
+            return_value=MagicMock(),
+        ) as mock_later,
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_track_point_in_time",
+            return_value=MagicMock(),
+        ),
+    ):
+        coordinator = BinCollectionCoordinator(hass, TEST_LOC)
+        # Patch the coordinator's own async_refresh so it raises rather than swallowing
+        coordinator.async_refresh = AsyncMock(side_effect=RuntimeError("hard failure"))
+        await coordinator._do_scheduled_refresh()
+
+        assert mock_later.called
+
+
+# ---------------------------------------------------------------------------
+# async_setup_entry
+# ---------------------------------------------------------------------------
+
+async def test_async_setup_entry(hass):
+    """async_setup_entry creates BinCollectionCoordinator and adds two entities."""
+    mock_entry = MagicMock()
+    mock_entry.data = {"location_id": TEST_LOC}
+
+    added_entities = []
+
+    def capture_entities(entities):
+        added_entities.extend(entities)
+
+    with (
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_get_bin_dates",
+            new_callable=AsyncMock,
+            return_value=[["dummy"]],
+        ),
+        patch(
+            "custom_components.auckland_bin_collection.sensor.async_track_point_in_time",
+            return_value=MagicMock(),
+        ),
+    ):
+        await async_setup_entry(hass, mock_entry, capture_entities)
+
+    assert len(added_entities) == 2
+    assert all(isinstance(e, AucklandBinCollection) for e in added_entities)


### PR DESCRIPTION
Auckland Council had blocked my IP with an Error 406 returned. This is suspected to reach the web server rate limit, so I change polling interval from per hour to per day fix time, with random variation. Actually poll per an hour shouldn't create any loading to the server but I recently see there is an App in AppStore doing the same things...... well....

Anyway I also add an attribute of last update time so we know if the result is update or not.

I also add more unit test to reach 100% coverage