### PR TITLE
Fix Web Parser due to Auckland Council HTML changes

### DIFF
--- a/custom_components/auckland_bin_collection/sensor.py
+++ b/custom_components/auckland_bin_collection/sensor.py
@@ -74,12 +74,14 @@ async def async_get_bin_dates(hass: HomeAssistant, location_id: str):
     extracted_data = []
     # We can assume first block is the household schedule
     for date_block in schedules[0].find_all("span", {"class": "acpl-icon-with-attribute left"}):
-        date_field = date_block.find("span", {"class", ""})
+        date_field = date_block.find("span", {"class": ""})
         if date_field:
-            collect_type = date_field.contents[0].strip().rstrip(':')
-            collect_date = date_field.find("b").string
-            if collect_date and collect_type:
-                extracted_data.append((collect_date.text, collect_type))
+            collect_type = str(date_field.contents[0]).strip().rstrip(':')
+            b_tag = date_field.find("b")
+            if b_tag and b_tag.string:
+                collect_date = str(b_tag.string).strip()
+                if collect_date and collect_type:
+                    extracted_data.append((collect_date, collect_type))
 
     if not extracted_data:
         raise UpdateFailed("Cannot retrieve bin dates")


### PR DESCRIPTION
Auckland Council recently updated their website's DOM structure by adding a new `span` element (`<span class="acpl-no-break">`) before the actual text elements. 

The previous parsing logic incorrectly passed a python set `{"class", ""}` instead of a dictionary `{"class": ""}` to the `find` method. This allowed BeautifulSoup to incorrectly match the newly added `<span class="acpl-no-break">`, which then resulted in an uncaught `AttributeError` when it couldn't locate the `<b>` tag within it.

This PR fixes the dictionary typo, preventing beautifulsoup from capturing the incorrect span, and safely evaluates the `<b_tag>` strings.