### PR TITLE
Schedule collection fetches after event expiry

### DIFF
--- a/custom_components/auckland_bin_collection/calendar.py
+++ b/custom_components/auckland_bin_collection/calendar.py
@@ -65,9 +65,10 @@ class AucklandBinCollectionCalendar(CoordinatorEntity, CalendarEntity):
         if not date_obj:
             return None
 
-        # Return just the first bin type from the earliest day as the immediate "next" event property state
+        # The entity state exposes only one current/next event, so include all
+        # bins collected on that date in the summary.
         return CalendarEvent(
-            summary=bin_types[0],
+            summary=", ".join(bin_types),
             start=date_obj,
             end=date_obj + timedelta(days=1),
             description="Auckland Council Bin Collection",

--- a/custom_components/auckland_bin_collection/sensor.py
+++ b/custom_components/auckland_bin_collection/sensor.py
@@ -28,10 +28,10 @@ UA_HEADER = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML
 
 # Scheduling configuration
 POLL_TIMEZONE = pytz.timezone("Pacific/Auckland")
-POLL_HOUR = 6          # Daily poll target: 6:00 AM NZ time
-POLL_JITTER_SECONDS = 1800   # ± random variation around the target time (seconds)
-RETRY_MIN_MINUTES = 30     # Minimum retry delay after a failed poll (minutes)
-RETRY_MAX_MINUTES = 90     # Maximum retry delay after a failed poll (minutes)
+POLL_HOUR = 12
+POLL_JITTER_SECONDS = 4 * 60 * 60
+RETRY_MIN_MINUTES = 120
+RETRY_MAX_MINUTES = 360
 
 
 def get_date_from_str(date_str: str) -> datetime.date:
@@ -101,29 +101,49 @@ async def async_get_bin_dates(hass: HomeAssistant, location_id: str):
     return sorted_data
 
 
-def _next_poll_time() -> datetime:
-    """Calculate the next daily poll time: POLL_HOUR NZ time ± POLL_JITTER_SECONDS."""
+def _next_poll_time(data) -> datetime:
+    """Calculate the next poll after the earliest known collection has ended."""
     now = datetime.now(POLL_TIMEZONE)
-    jitter = random.randint(-POLL_JITTER_SECONDS, POLL_JITTER_SECONDS)
-    target = now.replace(hour=POLL_HOUR, minute=0, second=0, microsecond=0) + timedelta(seconds=jitter)
+    collection_dates = []
+    for collection in data or []:
+        if not collection:
+            continue
+        collection_date = get_date_from_str(next(iter(collection)))
+        if collection_date:
+            collection_dates.append(collection_date)
 
-    # If the target time today has already passed, schedule for tomorrow
+    if not collection_dates:
+        return _retry_time()
+
+    event_end = min(collection_dates) + timedelta(days=1)
+    jitter = random.randint(-POLL_JITTER_SECONDS, POLL_JITTER_SECONDS)
+    target = POLL_TIMEZONE.localize(
+        datetime.combine(event_end, datetime.min.time())
+    ).replace(hour=POLL_HOUR) + timedelta(seconds=jitter)
+
     if target <= now:
-        target += timedelta(days=1)
+        return _retry_time()
 
     _LOGGER.debug(
-        "Next scheduled poll at %s (jitter: %+d sec)",
+        "Next scheduled poll at %s after collection data expires (jitter: %+d sec)",
         target.strftime("%Y-%m-%d %H:%M:%S %Z"),
         jitter,
     )
     return target
 
 
+def _retry_time() -> datetime:
+    """Calculate a randomized retry after a failed or stale poll."""
+    now = datetime.now(POLL_TIMEZONE)
+    delay_minutes = random.randint(RETRY_MIN_MINUTES, RETRY_MAX_MINUTES)
+    return now + timedelta(minutes=delay_minutes)
+
+
 class BinCollectionCoordinator(DataUpdateCoordinator):
-    """Custom coordinator that polls once daily at a fixed NZ time with random jitter.
+    """Custom coordinator that polls when the current collection data expires.
 
     On failure, it schedules a retry after a random delay instead of waiting
-    until the next daily window, to recover data without hammering the server.
+    until the next collection window, to recover data without hammering the server.
     """
 
     def __init__(self, hass: HomeAssistant, location_id: str) -> None:
@@ -139,15 +159,15 @@ class BinCollectionCoordinator(DataUpdateCoordinator):
         self._last_updated: datetime | None = None
 
     async def async_start(self) -> None:
-        """Start the coordinator: fetch immediately if no data, then schedule daily polls."""
+        """Start the coordinator: fetch immediately, then schedule from collection dates."""
         _LOGGER.debug("BinCollectionCoordinator starting")
         await self.async_refresh()  # Initial fetch on startup
         self._schedule_next_poll()
 
     def _schedule_next_poll(self) -> None:
-        """Schedule the next daily poll at the target time with jitter."""
+        """Schedule the next poll after the current collection data expires."""
         self._cancel_scheduled()
-        next_time = _next_poll_time()
+        next_time = _next_poll_time(self.data)
 
         @callback
         def _scheduled_refresh(_now: datetime) -> None:
@@ -160,11 +180,15 @@ class BinCollectionCoordinator(DataUpdateCoordinator):
     def _schedule_retry(self) -> None:
         """Schedule a retry after a random delay following a failed poll."""
         self._cancel_scheduled()
-        delay_minutes = random.randint(RETRY_MIN_MINUTES, RETRY_MAX_MINUTES)
-        delay_seconds = delay_minutes * 60
+        retry_time = _retry_time()
+        delay_seconds = max(
+            0,
+            int((retry_time - datetime.now(POLL_TIMEZONE)).total_seconds()),
+        )
 
         _LOGGER.warning(
-            "Last poll failed — retrying in %d minutes", delay_minutes
+            "Last poll failed, retrying at %s",
+            retry_time.strftime("%Y-%m-%d %H:%M:%S %Z"),
         )
 
         @callback
@@ -180,7 +204,7 @@ class BinCollectionCoordinator(DataUpdateCoordinator):
         try:
             await self.async_refresh()
             if self.last_update_success:
-                _LOGGER.debug("Scheduled poll succeeded — scheduling next daily poll")
+                _LOGGER.debug("Scheduled poll succeeded, scheduling next collection poll")
                 self._schedule_next_poll()
             else:
                 self._schedule_retry()

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -60,7 +60,7 @@ async def test_async_setup_entry(hass):
 @freeze_time("2023-01-01")
 @pytest.mark.asyncio
 async def test_calendar_next_event():
-    """Test the event property returns the single next immediate event."""
+    """Test the event property summarizes all bins on the next collection day."""
     m_coordinator = AsyncMock()
     m_coordinator.data = TEST_COORDINATOR_DATA
 
@@ -68,8 +68,7 @@ async def test_calendar_next_event():
     event = calendar.event
 
     assert isinstance(event, CalendarEvent)
-    # The first bin type of the first day
-    assert event.summary == "Rubbish"
+    assert event.summary == "Rubbish, Food scraps"
     assert event.start == date(2023, 1, 12)
     assert event.end == date(2023, 1, 13)
 
@@ -127,4 +126,3 @@ async def test_calendar_empty_data():
     
     events = await calendar.async_get_events(MagicMock(), start_date, end_date)
     assert len(events) == 0
-

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -157,41 +157,35 @@ TZ_NZ = pytz.timezone("Pacific/Auckland")
 
 # --- _next_poll_time --------------------------------------------------------
 
-@freeze_time("2024-06-01 03:00:00")  # 3 AM UTC → 15:00 NZ (before 6 AM next day)
-def test_next_poll_time_is_in_future():
+@freeze_time("2026-06-28 00:00:00")
+def test_next_poll_time_is_after_current_collection_event_end():
     """_next_poll_time should always return a time in the future."""
-    next_time = _next_poll_time()
+    next_time = _next_poll_time([{"Monday, 29 June": ["Rubbish"]}])
     now = datetime.now(TZ_NZ)
+
     assert next_time > now
+    assert next_time.date() == date(2026, 6, 30)
 
 
-@freeze_time("2024-06-01 03:00:00")  # 15:00 NZ — daily target (6 AM) already past
-def test_next_poll_time_schedules_tomorrow_when_past():
-    """When 6 AM today has already passed, schedule for tomorrow."""
-    next_time = _next_poll_time()
-    now = datetime.now(TZ_NZ)
-    assert next_time.date() == (now + timedelta(days=1)).date()
-
-
-@freeze_time("2024-06-01 17:00:00")  # 05:00 NZ — just before 6 AM
-def test_next_poll_time_schedules_today_when_not_yet_reached():
-    """When 6 AM today has not yet occurred, schedule for today."""
-    next_time = _next_poll_time()
-    now = datetime.now(TZ_NZ)
-    assert next_time.date() == now.date()
-
-
-@freeze_time("2024-06-01 03:00:00")
-def test_next_poll_time_within_jitter_bounds():
+@freeze_time("2026-06-28 00:00:00")
+def test_next_poll_time_within_collection_expiry_window():
     """The scheduled time must be within POLL_HOUR ± POLL_JITTER_SECONDS."""
-    # Run many times to exercise the random jitter
     for _ in range(50):
-        next_time = _next_poll_time()
-        # Convert to NZ local time for comparison
+        next_time = _next_poll_time([{"Monday, 29 June": ["Rubbish"]}])
         local = next_time.astimezone(TZ_NZ)
-        base = local.replace(hour=POLL_HOUR, minute=0, second=0, microsecond=0)
+        base = TZ_NZ.localize(datetime(2026, 6, 30, POLL_HOUR, 0, 0))
         diff_seconds = abs((local - base).total_seconds())
-        assert diff_seconds <= POLL_JITTER_SECONDS + 1  # +1 for float rounding
+        assert diff_seconds <= POLL_JITTER_SECONDS + 1
+
+
+@freeze_time("2026-06-30 20:00:00")
+def test_next_poll_time_uses_retry_window_when_collection_window_already_passed():
+    """Stale collection data uses the retry window instead of daily polling."""
+    next_time = _next_poll_time([{"Monday, 29 June": ["Rubbish"]}])
+    now = datetime.now(TZ_NZ)
+
+    assert now + timedelta(minutes=RETRY_MIN_MINUTES) <= next_time
+    assert next_time <= now + timedelta(minutes=RETRY_MAX_MINUTES)
 
 
 # --- async_start ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- schedule successful fetches after the earliest known collection event has ended
- randomize the refresh time around noon with a 4-hour jitter
- retry failed fetches after a randomized 2-6 hour delay
- show all bin types in the calendar entity's next-event summary

## Tests
- timeout 60 /tmp/auckland-bin-venv/bin/pytest /home/fishy/codex_work/homeassistant/auckland_bin_collection/tests