### PR TITLE
Prepare 0.4.0 HACS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,114 @@
-# Auckland Bin Collection for Home Assistant
+# Auckland Bin Collection
 
-A Home Assistant custom component grep the rubbish and recycle (food scraps soon!) bin collection date from Auckland Council website. User can make use of it to develop their own auotmation or notification.
+[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://hacs.xyz/)
+[![GitHub release](https://img.shields.io/github/v/release/fishy242/auckland_bin_collection)](https://github.com/fishy242/auckland_bin_collection/releases)
+[![GitHub license](https://img.shields.io/github/license/fishy242/auckland_bin_collection)](LICENSE)
 
-## Version
+Home Assistant custom integration for Auckland Council rubbish, recycling, and food scraps collection dates.
 
-| Version | Notes                                                                  |
-| ------- | ---------------------------------------------------------------------- |
-| 0.1.0   | First publish release                                                  |
-| 0.2.0   | Update with Auckland Council website to include food scraps collection |
-| 0.3.0   | Added native Calendar entity and optimized polling frequency           |
-| 0.3.1   | Always list "Food scraps" last so Rubbish/Recycle stay visible first   |
+## Features
+
+- UI configuration flow.
+- Native calendar entity for collection reminders and automations.
+- Sensor entities for dashboard display.
+- Separate calendar events for each bin type on the same day.
+- Food scraps are ordered last so rubbish and recycling stay visible first in compact calendar cards.
+- Fetching is scheduled around current collection data instead of polling every day.
 
 ## Installation
 
 ### HACS
 
-If you have [HACS](https://hacs.xyz/) setup in your Home Assistant, go to the HACS integration page, click the 3 dots menu on top right corner and choose Custom repositories. Add [this repository](https://github.com/fishy242/auckland_bin_collection) with Category set to Integration. After that you can download the integration.
+1. Open HACS in Home Assistant.
+2. Open the three-dot menu and choose **Custom repositories**.
+3. Add this repository URL:
 
-### Manual Install
+   ```text
+   https://github.com/fishy242/auckland_bin_collection
+   ```
 
-Copy the `auckland_bin_collection` folder from the [`custom_components`](https://github.com/fishy242/auckland_bin_collection/tree/master/custom_components) and put this into `config/custom_components` of your Home Assistant setup.
+4. Select **Integration** as the category.
+5. Install **Auckland Bin Collection**.
+6. Restart Home Assistant.
 
-## Setup
+### Manual
 
-This integration supports UI setup. Add the integration in Home Assistant Integrations settings page. Click the ADD INTEGRATION button and search for "Auckland Bin Collection".
+Copy `custom_components/auckland_bin_collection` from this repository into:
+
+```text
+<config>/custom_components/auckland_bin_collection
+```
+
+Restart Home Assistant after copying the files.
+
+## Configuration
+
+1. In Home Assistant, go to **Settings** > **Devices & services**.
+2. Select **Add integration**.
+3. Search for **Auckland Bin Collection**.
+4. Enter your Auckland Council location ID.
 
 ### Location ID
 
-To setup, you need the location ID of the address where you want to retrieve the bin collection date for. You can find the location ID from [Auckland Council Collection Day](https://www.aucklandcouncil.govt.nz/rubbish-recycling/rubbish-recycling-collections/Pages/rubbish-recycling-collection-days.aspx) webpage. Enter a full address in the webpage, then you will be directed to a page showing the collection day of the address you entered. Look into the URL of this page, the location ID is the 11 digits at the end of the URL. Enter this location ID when you are prompt during setup.
+Open the [Auckland Council collection day page](https://www.aucklandcouncil.govt.nz/rubbish-recycling/rubbish-recycling-collections/Pages/rubbish-recycling-collection-days.aspx), search for your address, then use the 11-digit ID from the result page URL.
 
-### Entities Created
+Example URL:
 
-Upon successful setup, a natively integrated **Calendar Entity** (`calendar.auckland_bin_collection`) will be created, alongside two **Sensor Entities** (`sensor.auckland_bin_collection_upcoming` and `sensor.auckland_bin_collection_next`). 
+```text
+https://www.aucklandcouncil.govt.nz/en/rubbish-recycling/rubbish-recycling-collections/rubbish-recycling-collection-days/12345678901.html
+```
 
-Both entity types automatically use the same underlying data with zero extra load, but are optimized for different use cases:
-* **Calendar:** Best for automations and reminders.
-* **Sensors:** Best for visual display on dashboard cards.
+In this example, the location ID is `12345678901`.
 
-## Usage
+## Entities
 
-### Calendar Entity
+| Entity | Description |
+| --- | --- |
+| `calendar.auckland_bin_collection` | Calendar events for upcoming collections. |
+| `sensor.auckland_bin_collection_upcoming` | Date and attributes for the next collection day. |
+| `sensor.auckland_bin_collection_next` | Date and attributes for the following collection day. |
 
-The calendar entity cleanly separates each bin collection type into its own discrete, all-day calendar event (e.g., an individual "Rubbish" event and an individual "Recycling" event on the same day). This allows you to write precise, condition-based automations using Home Assistant's native calendar features.
+### Calendar
 
-### Sensor State (Dashboard)
+The calendar entity returns separate all-day events for each bin type. If rubbish, recycling, and food scraps are collected on the same day, `calendar.get_events` returns three events.
 
-The state of the sensor is the date of the collection day.
+The calendar entity's current `message` attribute summarizes all bin types on the next collection day, for example:
 
-### Attributes
+```text
+Rubbish, Recycling, Food scraps
+```
 
-The table below shows the attributes of the sensor.
-| Attribute | Content |
-|-----------|---------|
-| location_id | Location ID of the location that the sensor referring to. |
-| date | Date string retrieve from the Auckland Council webpage. |
-| rubbish | `true` or `false` - Rubbish bin will be collected or not. |
-| recycle | `true` or `false` - Recycle bin will be collected or not. |
-| food scraps | `true` or `false` - Food scraps bin will be collected or not. |
-| query_url | The URL where the information retrieved from. |
-| friendly_name | Sensor's friendly name. |
+### Sensor Attributes
 
-### Automation Example (Recommended)
+| Attribute | Description |
+| --- | --- |
+| `location_id` | Auckland Council location ID. |
+| `date` | Collection date text from Auckland Council. |
+| `rubbish` | `true` when rubbish is collected on this date. |
+| `recycle` | `true` when recycling is collected on this date. |
+| `food scraps` | `true` when food scraps are collected on this date. |
+| `query_url` | Auckland Council page used for the location. |
+| `last_updated` | Last successful fetch timestamp. |
 
-Since the calendar generates multiple events per day (one for each bin type), triggering purely on the calendar event start will cause multiple actions to fire. 
+## Fetch Behaviour
 
-To receive a **single daily digest notification**, trigger your automation at a specific time and use `calendar.get_events` to retrieve all scheduled bins for that day:
+The integration fetches data when Home Assistant starts, then schedules future successful refreshes after the current collection data expires.
+
+For example, if the next collection event is on `2026-06-29` and ends at `2026-06-30 00:00:00`, the next scheduled fetch starts on `2026-06-30`.
+
+Successful refreshes are randomized around noon with a four-hour jitter, so the target window is roughly `08:00` to `16:00` local time. Failed fetches retry after a randomized `2` to `6` hour delay and continue retrying until a fetch succeeds.
+
+## Automation Example
+
+Use `calendar.get_events` when you want a single daily notification with every bin type collected that day:
 
 ```yaml
-alias: "Daily Bin Reminder"
+alias: Daily Bin Reminder
 mode: single
 trigger:
-  # Check at 7:00 AM every day
   - platform: time
-    at: "07:00:00" 
+    at: "07:00:00"
 action:
-  # Fetch all events occurring in the next 24 hours
   - service: calendar.get_events
     target:
       entity_id: calendar.auckland_bin_collection
@@ -83,11 +117,9 @@ action:
         hours: 24
     response_variable: scheduled_bins
 
-  # STOP execution if no bins are scheduled today
   - condition: template
     value_template: "{{ scheduled_bins['calendar.auckland_bin_collection']['events'] | length > 0 }}"
 
-  # Send exactly one notification summarizing all bins
   - service: notify.notify
     data:
       message: >
@@ -97,18 +129,24 @@ action:
         {% endfor %}
 ```
 
-### Dashboard Card (State Sensor)
+## Dashboard Example
 
-To easily display upcoming bins on your Home Assistant Dashboard, you can add a Markdown Card using the state sensors with the following content:
+Add a Markdown card using the state sensors:
 
 ```text
 Upcoming: **{{ state_attr('sensor.auckland_bin_collection_upcoming', 'date') }}**{% if state_attr('sensor.auckland_bin_collection_upcoming', 'rubbish') == 'true' %} <ha-icon icon="mdi:trash-can-outline"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_upcoming', 'recycle') == 'true' %} <ha-icon icon="mdi:recycle"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_upcoming', 'food scraps') == 'true' %} <ha-icon icon="mdi:compost"></ha-icon>{% endif %}
 
-Next:  **{{ state_attr('sensor.auckland_bin_collection_next', 'date') }}**{% if state_attr('sensor.auckland_bin_collection_next', 'rubbish') == 'true' %} <ha-icon icon="mdi:trash-can-outline"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_next', 'recycle') == 'true' %}<ha-icon icon="mdi:recycle"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_next', 'food scraps') == 'true' %} <ha-icon icon="mdi:compost"></ha-icon>{% endif %}
+Next: **{{ state_attr('sensor.auckland_bin_collection_next', 'date') }}**{% if state_attr('sensor.auckland_bin_collection_next', 'rubbish') == 'true' %} <ha-icon icon="mdi:trash-can-outline"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_next', 'recycle') == 'true' %} <ha-icon icon="mdi:recycle"></ha-icon>{% endif %}{% if state_attr('sensor.auckland_bin_collection_next', 'food scraps') == 'true' %} <ha-icon icon="mdi:compost"></ha-icon>{% endif %}
 ```
 
-Result will look like this.
+![Markdown card example](img/abc_markdown_card.png)
 
-![alt Markdown Card](img/abc_markdown_card.png)
+## Changelog
 
-Hope you find this integration useful :)
+| Version | Notes |
+| --- | --- |
+| 0.4.0 | Schedule fetches after current collection data expires; add randomized daytime refreshes and 2-6 hour retries; summarize all next-day bin types in the calendar entity message. |
+| 0.3.1 | Always list food scraps last so rubbish and recycling stay visible first. |
+| 0.3.0 | Added native calendar entity and optimized polling frequency. |
+| 0.2.0 | Updated parser for Auckland Council food scraps collection data. |
+| 0.1.0 | Initial release. |

--- a/custom_components/auckland_bin_collection/manifest.json
+++ b/custom_components/auckland_bin_collection/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/fishy242/auckland_bin_collection",
   "iot_class": "cloud_polling",
   "requirements": ["beautifulsoup4==4.12.0"],
-  "version": "0.3.1"
+  "version": "0.4.0"
 }


### PR DESCRIPTION
## Summary
- bump integration manifest version to 0.4.0
- rewrite README into a more standard HACS-style format
- document entities, fetch behavior, retry behavior, and examples
- add 0.4.0 changelog entry